### PR TITLE
feat: registrationsテーブルのカウントを全テーブル舐めるのをやめた

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -462,7 +462,7 @@ func (h *handlers) RegisterCourses(c echo.Context) error {
 
 		// すでに履修登録済みの科目は無視する
 		var count int
-		if err := tx.Get(&count, "SELECT COUNT(*) FROM `registrations` WHERE `course_id` = ? AND `user_id` = ?", course.ID, userID); err != nil {
+		if err := tx.Get(&count, "SELECT EXISTS(SELECT * FROM `registrations` WHERE `user_id` = ? AND `course_id` = ? limit 1)", userID, courseID); err != nil {
 			c.Logger().Error(err)
 			return c.NoContent(http.StatusInternalServerError)
 		}
@@ -1142,7 +1142,7 @@ func (h *handlers) SubmitAssignment(c echo.Context) error {
 	}
 
 	var registrationCount int
-	if err := tx.Get(&registrationCount, "SELECT COUNT(*) FROM `registrations` WHERE `user_id` = ? AND `course_id` = ? FOR SHARE", userID, courseID); err != nil {
+	if err := tx.Get(&registrationCount, "SELECT EXISTS(SELECT * FROM `registrations` WHERE `user_id` = ? AND `course_id` = ? limit 1 FOR SHARE)", userID, courseID); err != nil {
 		c.Logger().Error(err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
@@ -1567,7 +1567,7 @@ func (h *handlers) GetAnnouncementDetail(c echo.Context) error {
 	}
 
 	var registrationCount int
-	if err := tx.Get(&registrationCount, "SELECT COUNT(*) FROM `registrations` WHERE `course_id` = ? AND `user_id` = ?", announcement.CourseID, userID); err != nil {
+	if err := tx.Get(&registrationCount, "SELECT EXISTS(SELECT * FROM `registrations` WHERE `user_id` = ? AND `course_id` = ? limit 1 FOR SHARE)", userID, announcement.CourseID); err != nil {
 		c.Logger().Error(err)
 		return c.NoContent(http.StatusInternalServerError)
 	}


### PR DESCRIPTION

```
15:19:46.069058 raw score (34380) breakdown:
15:19:46.069064 SubmitAssignment    : 9718 回 (29154 点)
15:19:46.069066 GetAnnouncementList : 5226 回 (5226 点)
slackcat file benchmark uploaded to isulog (0.545s)
```